### PR TITLE
Manage adding/removing users for event threads

### DIFF
--- a/ui/eventView.py
+++ b/ui/eventView.py
@@ -1,5 +1,6 @@
 import discord
 from discord.ui import View, Button
+from bot import api
 
 
 class EventView(View):
@@ -23,6 +24,11 @@ class EventView(View):
         going.append(str(interaction.user.id))
         self.event.going = str.join(", ", going)
         await self.event.refresh(interaction)
+        try:
+            print(f"adding {interaction.user.name} to thread for {self.event.name}")
+            await api.bot.get_channel(self.event.thread).add_user(interaction.user)
+        except Exception as e:
+            print(f"unable to add {interaction.user.name} to thread: {e}")
 
     @discord.ui.button(label="✖ Not Going",
                        custom_id="notAttending",
@@ -44,6 +50,11 @@ class EventView(View):
         if not self.event.going:
             self.event.going = "None"
         await self.event.refresh(interaction)
+        try:
+            print(f"removing {interaction.user.name} from thread for {self.event.name}")
+            await api.bot.get_channel(self.event.thread).remove_user(interaction.user)
+        except Exception as e:
+            print(f"unable to remove {interaction.user.name} from thread: {e}")
 
     @discord.ui.button(label="📝 Edit",
                        custom_id="edit",


### PR DESCRIPTION
One possible approach to improving notifications for event threads by just adding a user to the event thread when they use the "Going" button and removing the user from the thread when they use the "Not Going" button.

I think the benefit is that users would see notifications for exactly the events they are attending.

The potential downside, at least that I noticed so far, is that it may clutter the event thread with `<bot> added/removed <user> from the thread` messages (although this has the side effect of notifying the other attendees when someone joins or leaves the event, which could be nice).